### PR TITLE
Fixes to options

### DIFF
--- a/gerbil/__init__.py
+++ b/gerbil/__init__.py
@@ -1,34 +1,29 @@
-from os.path import splitext, isfile, basename
 from optparse import OptionParser
-from .gerbil import create_footer, merge_files
+from .gerbil import create_footer, merge_files, create_font_args
 
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-
-
-def create_font_args(options):
-    if isfile(options.font):
-        font_name, font_file = (basename(splitext(options.font)[0]),
-                                options.font)
-        return font_name, options.font
-    else:
-        print "Can't find {}".format(options.text)
 
 
 def main():
     parser = OptionParser()
     parser.add_option('-t', '--text',
                       help="The text to appear on footer the page.")
-    parser.add_option('-f', '--font',
-                      help="The TrueType font file to be used (*.ttf)")
-    parser.add_option('-a', '--author',
-                      help="The author to appear in metadata.")
-    parser.add_option('-s', '--subject',
-                      help="The subject to appear in metadata.")
     parser.add_option('-i', '--input',
                       help="The input file for the text to be added to.")
     parser.add_option('-o', '--output',
                       help="The ouput file to be saved.")
+    parser.add_option('-f', '--font',
+                      default="Bliss-Regular.ttf",
+                      help="Path to the TrueType font file to be used (*.ttf)")
+    parser.add_option('-s', '--size',
+                      type="float",
+                      default=8,
+                      help="The font size px to be used (default = 8)")
+    parser.add_option('-a', '--author',
+                      help="The author to appear in metadata.")
+    parser.add_option('-u', '--subject',
+                      help="The subject to appear in metadata.")
     parser.add_option('-p', '--padding',
                       help="NOT IMPLEMENTED YET !! - The padding from the \
                             bottom of the page ")
@@ -39,9 +34,17 @@ def main():
     parser.add_option('--landscape',
                       action="store_true", dest="landscape", default=False,
                       help="Specify landscape orientation, otherwise portrait")
-    
+
     (options, args) = parser.parse_args()
 
-    pdfmetrics.registerFont(TTFont(*create_font_args(options)))
-    f = create_footer(options)
-    merge_files(options, f)
+    err = create_font_args(options)
+    if not err:
+        pdfmetrics.registerFont(TTFont(options.font_name, options.font_path))
+        f, err = create_footer(options)
+        if err is None:
+            merge_files(options, f)
+        else:
+            print err
+    else:
+        print "Can't find {} Exiting".format(options.font)
+        exit(1)

--- a/gerbil/gerbil.py
+++ b/gerbil/gerbil.py
@@ -1,4 +1,5 @@
 import os
+from os.path import splitext, isfile, basename
 from optparse import OptionParser
 import StringIO
 from PyPDF2 import PdfFileWriter, PdfFileReader
@@ -12,8 +13,6 @@ from reportlab.pdfbase.ttfonts import TTFError
 
 from clint.textui import progress
 
-pdfmetrics.registerFont(TTFont('Bliss-Regular', 'Bliss-Regular.ttf'))
-
 
 def get_page_size(options, default=A4):
     if options.page_width and options.page_height:
@@ -23,31 +22,68 @@ def get_page_size(options, default=A4):
     return width, height
 
 
+def test_if_file_exists(filename):
+    if filename is None:
+        return False
+    return isfile(filename)
+
+
+def create_font_args(options):
+    if test_if_file_exists(options.font):
+        font_name, font_path = (basename(splitext(options.font)[0]),
+                                options.font)
+        options.font_name = font_name
+        options.font_path = font_path
+        return False
+    else:
+        return True
+
+
 def create_footer(options):
+    if not options.text:
+        return None, "No text to write, exiting"
+
     pdf = StringIO.StringIO()
     width, height = get_page_size(options)
     if options.landscape:
         width, height = height, width
     can = canvas.Canvas(pdf, pagesize=(width, height))
     can.setFillColor(gray)
-    can.setFont('Bliss-Regular', 8)
-    can.setAuthor(options.author)
-    can.setSubject(options.subject)
+    size = 8
+    if options.size:
+        size = options.size
+    can.setFont(options.font_name, size)
     can.drawCentredString(width / 2.0, height / 2.0, options.text)
     can.save()
-    return pdf
+    return pdf, None
 
 
 def merge_files(options, footer):
     footer.seek(0)
     new_pdf = PdfFileReader(footer)
+
+    if not test_if_file_exists(options.input):
+        print "Could not read the input file - did you specify one?"
+        exit(1)
+
+    if not options.output:
+        print "No output path specified"
+        exit(1)
+
     try:
         book = PdfFileReader(open(options.input, "rb"))
     except Exception, e:
         print "Unable to load input PDF - {}".format(e)
-        exit()
+        exit(1)
 
     output = PdfFileWriter()
+
+    if options.author:
+        output.addMetadata({"/Author": options.author})
+
+    if options.subject:
+        output.addMetadata({"/Subject": options.subject})
+
     for index, page in progress.dots(enumerate(book.pages)):
         page = book.getPage(index)
         page.mergePage(new_pdf.getPage(0))
@@ -57,8 +93,3 @@ def merge_files(options, footer):
     output.write(outputStream)
     outputStream.close()
     print "Written {}".format(options.output)
-
-
-def test_if_file_exists(filename):
-    if os.path.isfile(filename):
-        return True


### PR DESCRIPTION
The following flags now work correctly

```
-f —font, -s —size, -a —author, -u —subject 
```

Also gives friendly message and clean exit if any of  

```
-i —input, -o —output or -t —text flags 
```

are not supplied, or if the file specified at

```
-f --font
```

cannot be found
